### PR TITLE
windows: cannot find -l:narray.so fix

### DIFF
--- a/ext/narray_ffi_c/extconf.rb
+++ b/ext/narray_ffi_c/extconf.rb
@@ -19,7 +19,7 @@ unless have_header("narray.h")
       end
       $CPPFLAGS = "-I" << path << "/ " << $CPPFLAGS
       if /cygwin|mingw/ =~ RUBY_PLATFORM then
-        $LDFLAGS = "-L" << path << "/" << $LDFLAGS
+        $LDFLAGS = "-L" << path << "/ " << $LDFLAGS
       end
     end
   rescue LoadError


### PR DESCRIPTION
a space was missing between library search path and opt

![image](https://user-images.githubusercontent.com/35939151/45470266-20e93100-b6fb-11e8-8203-f9379f5fbdb7.png)
